### PR TITLE
fix: entry comparison without datetime

### DIFF
--- a/src/main/java/seedu/pocketpal/data/entry/Entry.java
+++ b/src/main/java/seedu/pocketpal/data/entry/Entry.java
@@ -17,7 +17,7 @@ public class Entry implements Serialisable {
     private Category category;
     private String description;
     private double amount;
-    private String dateTime;
+    private final String dateTime;
 
     public Entry(String description, double amount, Category category) {
         assert amount >= 0 : "Entry amount must be non-negative!";
@@ -30,6 +30,31 @@ public class Entry implements Serialisable {
         this.dateTime = dateTime.format(DateTimeFormatter.ofPattern("d MMM uuuu, HH:mm:ss"));
     }
 
+    /**
+     * Compare to another entry. Ignores DateTime in both entries.
+     *
+     * @param entry Entry to compare
+     * @return true if both entry is the same as this, false otherwise
+     */
+    public boolean equals(Entry entry) {
+        return equals(entry, false);
+    }
+
+    /**
+     * Compare to another entry.
+     *
+     * @param entry       Entry to compare
+     * @param compareDate True if date and time in both entries need to be the same
+     * @return true if both entry is the same as this, false otherwise
+     */
+    public boolean equals(Entry entry, boolean compareDate) {
+        boolean isSameAmount = amount == entry.getAmount();
+        boolean isSameCategory = category == entry.getCategory();
+        boolean isSameDescription = description.equals(entry.getDescription());
+        boolean isSameDateTime = dateTime.compareTo(entry.getDateTime()) == 0;
+        return isSameAmount && isSameCategory && isSameDescription && (!compareDate || isSameDateTime);
+    }
+
     public double getAmount() {
         return amount;
     }
@@ -38,7 +63,7 @@ public class Entry implements Serialisable {
         return category;
     }
 
-    public String getDateTime(){
+    public String getDateTime() {
         return dateTime;
     }
 

--- a/src/main/java/seedu/pocketpal/data/entrylog/EntryLog.java
+++ b/src/main/java/seedu/pocketpal/data/entrylog/EntryLog.java
@@ -57,6 +57,24 @@ public class EntryLog implements Serialisable {
     }
 
     /**
+     * Compare to another EntryLog. Ignores DateTime in both entries.
+     *
+     * @param entries EntryLog to compare
+     * @return true if both have the same entries, false otherwise
+     */
+    public boolean equals(EntryLog entries) {
+        if (getSize() != entries.getSize()) {
+            return false;
+        }
+        for (int i = 1; i <= getSize(); ++i) {
+            if (!getEntry(i).equals(entries.getEntry(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
      * Filter items by amount.
      * Can be chained with other filter* methods to filter multiple entries.
      *
@@ -140,7 +158,7 @@ public class EntryLog implements Serialisable {
     /**
      * This method is called in execute method to improve code readability.
      *
-     * @param  numEntries The number of recent entries to view
+     * @param numEntries The number of recent entries to view
      * @return trimmed list containing the latest "N" number of entries, where N is specified in the view command
      */
     public EntryLog getLatestEntries(int numEntries) {

--- a/src/test/java/seedu/pocketpal/backend/BackendTestUtil.java
+++ b/src/test/java/seedu/pocketpal/backend/BackendTestUtil.java
@@ -47,10 +47,10 @@ public abstract class BackendTestUtil {
     }
 
     public static boolean isSameEntry(Entry entry1, Entry entry2) {
-        return entry1.serialise().equals(entry2.serialise());
+        return entry1.equals(entry2);
     }
 
     public static boolean isSameEntryLog(EntryLog entryLog1, EntryLog entryLog2) {
-        return entryLog1.serialise().equals(entryLog2.serialise());
+        return entryLog1.equals(entryLog2);
     }
 }


### PR DESCRIPTION
CI was previously failing due to the introduction of DateTime. The previous implementation depended on the JSON-serialised entry, which did not account for different DateTime created during the (de)serialisation when making requests to the backend.