### PR TITLE
`Backend`: improve code defensiveness

### DIFF
--- a/src/main/java/pocketpal/backend/constants/MiscellaneousConstants.java
+++ b/src/main/java/pocketpal/backend/constants/MiscellaneousConstants.java
@@ -1,7 +1,9 @@
 package pocketpal.backend.constants;
 
+import java.util.regex.Pattern;
+
 public final class MiscellaneousConstants {
-    
+
     public static final String GENERAL_STORAGE_ERROR_MESSAGE = "Error reading data from line: ";
     public static final String INVALID_AMOUNT_ERROR_MESSAGE = "Amount is not valid for line: ";
     public static final String INVALID_CATEGORY_ERROR_MESSAGE = "Category is not valid for line: ";
@@ -9,7 +11,10 @@ public final class MiscellaneousConstants {
 
     public static final String DATETIME_PATTERN = "d MMM uuuu; HH:mm";
     public static final String METHOD_NOT_IMPLEMENTED = "Unexpected request. This method not implemented.";
-
+    public static final Pattern PATTERN_AMOUNT_2DP = Pattern
+            .compile("^(\\d{0,9}.(\\d{1,2}0*))$|^(\\d{1,9}(.\\d{0,2}0*)?)$");
+    public static final double AMOUNT_MAX_DOUBLE = 999999999.99;
+    public static final double AMOUNT_MIN_DOUBLE = 0.01;
     private MiscellaneousConstants(){
     }
 }

--- a/src/main/java/pocketpal/backend/constants/MiscellaneousConstants.java
+++ b/src/main/java/pocketpal/backend/constants/MiscellaneousConstants.java
@@ -8,6 +8,7 @@ public final class MiscellaneousConstants {
     public static final String INVALID_DATE_ERROR_MESSAGE = "Date is not valid for line: ";
 
     public static final String DATETIME_PATTERN = "d MMM uuuu; HH:mm";
+    public static final String METHOD_NOT_IMPLEMENTED = "Unexpected request. This method not implemented.";
 
     private MiscellaneousConstants(){
     }

--- a/src/main/java/pocketpal/backend/endpoints/Endpoint.java
+++ b/src/main/java/pocketpal/backend/endpoints/Endpoint.java
@@ -19,6 +19,7 @@ public abstract class Endpoint extends EndpointUtil implements Requestable {
      */
     @Override
     public Response handleRequest(Request request) {
+        assert request != null : "Unexpected null request method";
         switch (request.getRequestMethod()) {
         case DELETE:
             logger.info("Routing DELETE request");

--- a/src/main/java/pocketpal/backend/endpoints/Endpoint.java
+++ b/src/main/java/pocketpal/backend/endpoints/Endpoint.java
@@ -7,7 +7,7 @@ import pocketpal.communication.Response;
 
 import java.util.logging.Logger;
 
-public abstract class Endpoint implements Requestable {
+public abstract class Endpoint extends EndpointUtil implements Requestable {
     private static final Logger logger = Logger.getLogger(Endpoint.class.getName());
 
     /**

--- a/src/main/java/pocketpal/backend/endpoints/Endpoint.java
+++ b/src/main/java/pocketpal/backend/endpoints/Endpoint.java
@@ -1,41 +1,81 @@
 package pocketpal.backend.endpoints;
 
+import pocketpal.backend.constants.MiscellaneousConstants;
 import pocketpal.communication.Request;
 import pocketpal.communication.Requestable;
 import pocketpal.communication.Response;
 
-public abstract class Endpoint implements Requestable {
-    private static final String METHOD_NOT_IMPLEMENTED = "Unexpected request. This method not implemented.";
+import java.util.logging.Logger;
 
+public abstract class Endpoint implements Requestable {
+    private static final Logger logger = Logger.getLogger(Endpoint.class.getName());
+
+    /**
+     * Routes the incoming request to the appropriate handler, if valid.
+     * Otherwise, an AssertionError will be thrown.
+     *
+     * @param request Request to be handled
+     * @return Response containing requested information
+     */
     @Override
     public Response handleRequest(Request request) {
         switch (request.getRequestMethod()) {
         case DELETE:
+            logger.info("Routing DELETE request");
             return handleDelete(request);
         case GET:
+            logger.info("Routing GET request");
             return handleGet(request);
         case PATCH:
+            logger.info("Routing PATCH request");
             return handlePatch(request);
         case POST:
+            logger.info("Routing POST request");
             return handlePost(request);
         default:
-            throw new AssertionError(METHOD_NOT_IMPLEMENTED);
+            // should not be executed, unless new request methods are implemented
+            logger.severe("Unable to route request: " + request.getRequestMethod());
+            throw new AssertionError(MiscellaneousConstants.METHOD_NOT_IMPLEMENTED);
         }
     }
 
+    /**
+     * Send a DELETE request to the endpoint
+     *
+     * @param request Request to be handled
+     * @return Response containing requested information
+     */
     public Response handleDelete(Request request) {
-        throw new AssertionError(METHOD_NOT_IMPLEMENTED);
+        throw new AssertionError(MiscellaneousConstants.METHOD_NOT_IMPLEMENTED);
     }
 
+    /**
+     * Send a GET request to the endpoint
+     *
+     * @param request Request to be handled
+     * @return Response containing requested information
+     */
     public Response handleGet(Request request) {
-        throw new AssertionError(METHOD_NOT_IMPLEMENTED);
+        throw new AssertionError(MiscellaneousConstants.METHOD_NOT_IMPLEMENTED);
     }
 
+    /**
+     * Send a PATCH request to the endpoint
+     *
+     * @param request Request to be handled
+     * @return Response containing requested information
+     */
     public Response handlePatch(Request request) {
-        throw new AssertionError(METHOD_NOT_IMPLEMENTED);
+        throw new AssertionError(MiscellaneousConstants.METHOD_NOT_IMPLEMENTED);
     }
 
+    /**
+     * Send a POST request to the endpoint
+     *
+     * @param request Request to be handled
+     * @return Response containing requested information
+     */
     public Response handlePost(Request request) {
-        throw new AssertionError(METHOD_NOT_IMPLEMENTED);
+        throw new AssertionError(MiscellaneousConstants.METHOD_NOT_IMPLEMENTED);
     }
 }

--- a/src/main/java/pocketpal/backend/endpoints/EndpointUtil.java
+++ b/src/main/java/pocketpal/backend/endpoints/EndpointUtil.java
@@ -1,0 +1,50 @@
+package pocketpal.backend.endpoints;
+
+import pocketpal.frontend.constants.MessageConstants;
+import pocketpal.frontend.exceptions.InvalidArgumentsException;
+import pocketpal.frontend.util.StringUtil;
+
+import java.util.regex.Matcher;
+
+import static pocketpal.backend.constants.MiscellaneousConstants.AMOUNT_MIN_DOUBLE;
+import static pocketpal.backend.constants.MiscellaneousConstants.PATTERN_AMOUNT_2DP;
+
+public class EndpointUtil {
+    /**
+     * Parses the input string and returns the corresponding positive integer.
+     *
+     * @param number The string to be parsed
+     * @return Positive integer
+     * @throws NumberFormatException If string is not an integer, or is non-positive
+     */
+    public static int getPositiveIntegerFromString(String number) throws NumberFormatException {
+        assert number != null : "Unexpected null string";
+        int result = Integer.parseInt(number);
+        if (result <= 0) {
+            throw new NumberFormatException();
+        }
+        return result;
+    }
+
+    /**
+     * Parses the input string and returns the corresponding amount.
+     * Checks if the string is positive, has at most 9 whole digits, and has up to 2 decimal points.
+     *
+     * @param amount The string to be parsed
+     * @return Positive Double with at most 2 decimal points
+     */
+    public static double getAmountFromString(String amount) throws InvalidArgumentsException {
+        assert amount != null : "Unexpected null string";
+        try {
+            double result = Double.parseDouble(amount);
+            Matcher amountMatcher = PATTERN_AMOUNT_2DP.matcher(StringUtil.doubleToString(result));
+            boolean isValidAmount = amountMatcher.find() && result >= AMOUNT_MIN_DOUBLE;
+            if (!isValidAmount) {
+                throw new NumberFormatException();
+            }
+            return result;
+        } catch (NumberFormatException e) {
+            throw new InvalidArgumentsException(MessageConstants.MESSAGE_INVALID_PRICE);
+        }
+    }
+}

--- a/src/main/java/pocketpal/backend/endpoints/EndpointUtil.java
+++ b/src/main/java/pocketpal/backend/endpoints/EndpointUtil.java
@@ -44,7 +44,7 @@ public class EndpointUtil {
             }
             return result;
         } catch (NumberFormatException e) {
-            throw new InvalidArgumentsException(MessageConstants.MESSAGE_INVALID_PRICE);
+            throw new InvalidArgumentsException(MessageConstants.MESSAGE_INVALID_AMOUNT);
         }
     }
 }

--- a/src/main/java/pocketpal/backend/endpoints/EntriesEndpoint.java
+++ b/src/main/java/pocketpal/backend/endpoints/EntriesEndpoint.java
@@ -1,14 +1,17 @@
 package pocketpal.backend.endpoints;
 
+import pocketpal.backend.constants.MiscellaneousConstants;
 import pocketpal.communication.Request;
 import pocketpal.communication.RequestParams;
 import pocketpal.communication.Response;
 import pocketpal.communication.ResponseStatus;
 import pocketpal.data.entrylog.EntryLog;
 import pocketpal.frontend.constants.MessageConstants;
+import pocketpal.frontend.exceptions.InvalidArgumentsException;
 import pocketpal.frontend.exceptions.InvalidCategoryException;
 import pocketpal.frontend.exceptions.InvalidDateException;
 import pocketpal.frontend.util.CategoryUtil;
+import pocketpal.frontend.util.StringUtil;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -32,10 +35,9 @@ public class EntriesEndpoint extends Endpoint {
     public Response handleGet(Request request) {
         logger.info("/entries [GET]: request received");
         assert request != null;
-        if (request.hasParam(RequestParams.GET_SIZE)) {
-            return handleGetSize();
-        }
-        return handleGetEntries(request);
+        return request.hasParam(RequestParams.GET_SIZE)
+                ? handleGetSize()
+                : handleGetEntries(request);
     }
 
     /**
@@ -58,20 +60,34 @@ public class EntriesEndpoint extends Endpoint {
      */
     private Response handleGetEntries(Request request) {
         logger.info("/entries [GET]: request entries");
-        final EntryLog entriesToFilter = request.hasParam(RequestParams.NUM_ENTRIES)
-                ? entries.getLatestEntries(Integer.parseInt(request.getParam(RequestParams.NUM_ENTRIES)))
-                : entries;
 
         try {
-            final EntryLog filteredEntries = handleGetEntriesFilter(request, entriesToFilter);
+            // filter entries by parameters
+            final EntryLog filteredEntries = handleGetEntriesFilter(request, entries);
             logger.info("/entries [GET]: OK" + request.getBody());
-            return new Response(ResponseStatus.OK, filteredEntries.serialise());
+            if (!request.hasParam(RequestParams.NUM_ENTRIES)) {
+                return new Response(ResponseStatus.OK, filteredEntries.serialise());
+            }
+            // return recent N entries
+            final int numberOfEntriesRequested = getPositiveIntegerFromString(request
+                    .getParam(RequestParams.NUM_ENTRIES));
+            final EntryLog recentEntries = filteredEntries.getLatestEntries(numberOfEntriesRequested);
+            return new Response(ResponseStatus.OK, recentEntries.serialise());
         } catch (InvalidCategoryException e) {
             logger.warning("/entries [GET]: unknown filter category" + request.getBody());
             return new Response(ResponseStatus.UNPROCESSABLE_CONTENT, MessageConstants.MESSAGE_INVALID_CATEGORY);
-        } catch (InvalidDateException e){
+        } catch (InvalidDateException e) {
             logger.warning("/entries [GET]: invalid date");
             return new Response(ResponseStatus.UNPROCESSABLE_CONTENT, MessageConstants.MESSAGE_MIXED_DATE);
+        } catch (NumberFormatException e) {
+            logger.warning("/entries [GET]: invalid number of entries requested");
+            return new Response(
+                    ResponseStatus.UNPROCESSABLE_CONTENT,
+                    MessageConstants.MESSAGE_INVALID_NUMBER_OF_ENTRIES
+            );
+        } catch (InvalidArgumentsException e) {
+            logger.warning("/entries [GET]: invalid arguments");
+            return new Response(ResponseStatus.UNPROCESSABLE_CONTENT, e.getMessage());
         }
     }
 
@@ -89,18 +105,13 @@ public class EntriesEndpoint extends Endpoint {
      * @throws InvalidCategoryException If category parameter is invalid
      */
     private EntryLog handleGetEntriesFilter(Request request, EntryLog entries) throws InvalidCategoryException,
-            InvalidDateException {
+            InvalidDateException, InvalidArgumentsException {
         logger.info("/entries [GET]: filtering entries");
         EntryLog filteredEntries = entries;
-        String category = request.getParam(RequestParams.FILTER_BY_CATEGORY);
-        try {
-            if (request.hasParam(RequestParams.FILTER_BY_CATEGORY)) {
-                logger.info("/entries [GET]: filter by category - " + category);
-                filteredEntries = filteredEntries.filterByCategory(CategoryUtil.convertStringToCategory(category));
-            }
-        } catch (InvalidCategoryException e) {
-            logger.warning("/entries [GET]: received invalid category - " + category);
-            throw e;
+        final String category = request.getParam(RequestParams.FILTER_BY_CATEGORY);
+        if (request.hasParam(RequestParams.FILTER_BY_CATEGORY)) {
+            logger.info("/entries [GET]: filter by category - " + category);
+            filteredEntries = filteredEntries.filterByCategory(CategoryUtil.convertStringToCategory(category));
         }
 
         if (request.hasParam(RequestParams.FILTER_BY_QUERY)) {
@@ -109,32 +120,26 @@ public class EntriesEndpoint extends Endpoint {
             filteredEntries = filteredEntries.filterByQuery(query);
         }
 
-        boolean hasAmountStart = request.hasParam(RequestParams.FILTER_BY_AMOUNT_START);
-        boolean hasAmountEnd = request.hasParam(RequestParams.FILTER_BY_AMOUNT_END);
+        // filter entries by amounts
+        final boolean hasAmountStart = request.hasParam(RequestParams.FILTER_BY_AMOUNT_START);
+        final boolean hasAmountEnd = request.hasParam(RequestParams.FILTER_BY_AMOUNT_END);
+        final double filterAmountStart = hasAmountStart
+                ? getAmountFromString(request.getParam(RequestParams.FILTER_BY_AMOUNT_START))
+                : MiscellaneousConstants.AMOUNT_MIN_DOUBLE;
+        final double filterAmountEnd = hasAmountEnd
+                ? getAmountFromString(request.getParam(RequestParams.FILTER_BY_AMOUNT_END))
+                : MiscellaneousConstants.AMOUNT_MAX_DOUBLE;
+        logger.info("/entries [GET]: filter amount "
+                + "(start: " + filterAmountStart
+                + ", end: " + StringUtil.doubleToString(filterAmountEnd) + ")");
+        filteredEntries = filteredEntries.filterByAmount(filterAmountStart, filterAmountEnd);
+
+        // @@author leonghuenweng
+        // filter entries by date
         boolean hasStartDate = request.hasParam(RequestParams.FILTER_BY_TIME_START);
         boolean hasEndDate = request.hasParam(RequestParams.FILTER_BY_TIME_END);
         boolean isFilterBetweenDates = hasStartDate && hasEndDate;
-        boolean isFilterAmountRange = hasAmountStart && hasAmountEnd;
-        boolean isFilterMinAmount = hasAmountStart && !hasAmountEnd;
-        boolean isFilterMaxAmount = !hasAmountStart && hasAmountEnd;
-
-        if (isFilterAmountRange) {
-            double amountStart = Double.parseDouble(request.getParam(RequestParams.FILTER_BY_AMOUNT_START));
-            double amountEnd = Double.parseDouble(request.getParam(RequestParams.FILTER_BY_AMOUNT_END));
-            logger.info("/entries [GET]: filter by range (start: " + amountStart + ", end: " + amountEnd + ")");
-            filteredEntries = filteredEntries.filterByAmount(amountStart, amountEnd);
-        }
-        if (isFilterMinAmount) {
-            double amountStart = Double.parseDouble(request.getParam(RequestParams.FILTER_BY_AMOUNT_START));
-            logger.info("/entries [GET]: filter by amount >= " + amountStart);
-            filteredEntries = filteredEntries.filterByAmount(amountStart, Double.MAX_VALUE);
-        }
-        if (isFilterMaxAmount) {
-            double amountEnd = Double.parseDouble(request.getParam(RequestParams.FILTER_BY_AMOUNT_END));
-            logger.info("/entries [GET]: filter by amount <= " + amountEnd);
-            filteredEntries = filteredEntries.filterByAmount(0, amountEnd);
-        }
-        if (isFilterBetweenDates){
+        if (isFilterBetweenDates) {
             String startDateString = request.getParam(RequestParams.FILTER_BY_TIME_START);
             String endDateString = request.getParam(RequestParams.FILTER_BY_TIME_END);
             DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yy HH:mm");
@@ -143,8 +148,9 @@ public class EntriesEndpoint extends Endpoint {
 
             logger.info(
                     "/entries [GET]: filter by date (start: " + startDateString + ", end: " + endDateString + ")");
-            filteredEntries = filteredEntries.filterBetweenDates(startDateTime,endDateTime);
+            filteredEntries = filteredEntries.filterBetweenDates(startDateTime, endDateTime);
         }
+        // @@author
 
         return filteredEntries;
     }

--- a/src/main/java/pocketpal/frontend/commands/ViewCommand.java
+++ b/src/main/java/pocketpal/frontend/commands/ViewCommand.java
@@ -2,6 +2,7 @@
 package pocketpal.frontend.commands;
 
 import pocketpal.backend.Backend;
+import pocketpal.backend.constants.MiscellaneousConstants;
 import pocketpal.data.entry.Category;
 import pocketpal.data.entrylog.EntryLog;
 import pocketpal.data.parsing.EntryLogParser;
@@ -26,7 +27,8 @@ public class ViewCommand extends Command {
     private final Double priceToViewMax;
 
     public ViewCommand(int numberOfEntriesToView) {
-        this(numberOfEntriesToView, null, 0.0 , Double.MAX_VALUE, "", "");
+        this(numberOfEntriesToView, null, MiscellaneousConstants.AMOUNT_MIN_DOUBLE,
+                MiscellaneousConstants.AMOUNT_MAX_DOUBLE, "", "");
     }
 
     public ViewCommand(int numberOfEntriesToView,
@@ -63,15 +65,15 @@ public class ViewCommand extends Command {
             request.addParam(RequestParams.FILTER_BY_TIME_END, endDateString);
         }
 
-        request.addParam(RequestParams.FILTER_BY_AMOUNT_START, String.valueOf(priceToViewMin));
-        request.addParam(RequestParams.FILTER_BY_AMOUNT_END, String.valueOf(priceToViewMax));
+        request.addParam(RequestParams.FILTER_BY_AMOUNT_START,String.format("%f", priceToViewMin));
+        request.addParam(RequestParams.FILTER_BY_AMOUNT_END, String.format("%f", priceToViewMax));
 
         Response response = backend.requestEndpointEntries(request);
-        EntryLog relevantEntries = EntryLogParser.deserialise(response.getData());
         if (response.getResponseStatus() == ResponseStatus.UNPROCESSABLE_CONTENT) {
-            throw new InvalidCategoryException(MessageConstants.MESSAGE_INVALID_CATEGORY);
+            throw new InvalidCategoryException(response.getData());
         }
 
+        EntryLog relevantEntries = EntryLogParser.deserialise(response.getData());
         if (categoryToView != null) {
             ui.printEntriesToBeViewed(relevantEntries, categoryToView);
         } else {

--- a/src/main/java/pocketpal/frontend/constants/MessageConstants.java
+++ b/src/main/java/pocketpal/frontend/constants/MessageConstants.java
@@ -50,8 +50,10 @@ public final class MessageConstants {
     public static final String MESSAGE_INVALID_CATEGORY = "Please specify a valid category!";
     public static final String MESSAGE_INVALID_DESCRIPTION = "Description can only contain letters and numbers!";
     public static final String MESSAGE_INVALID_ID = "Please enter a valid numerical index!";
-    public static final String MESSAGE_INVALID_PRICE = "Please enter a valid price!";
-    public static final String MESSAGE_INVALID_PRICE_RANGE = "Please specify a valid price range!";
+    public static final String MESSAGE_INVALID_AMOUNT = "Please enter a valid amount!" + NEWLINE
+            + "Value should be between 0.01 and 999999999.99";
+    public static final String MESSAGE_INVALID_AMOUNT_RANGE = "Please specify a valid range!" + NEWLINE
+            + "Values should be between 0 and 1000000000";
     public static final String MESSAGE_MISSING_ARGS_ADD = "Please specify the description, category and price!";
     public static final String MESSAGE_MISSING_PRICE_ADD = "Please specify the price using the '-p' flag!";
     public static final String MESSAGE_MISSING_DESCRIPTION_ADD = "Please specify the description using the '-d' flag!";

--- a/src/main/java/pocketpal/frontend/exceptions/InvalidEntryIdException.java
+++ b/src/main/java/pocketpal/frontend/exceptions/InvalidEntryIdException.java
@@ -1,10 +1,16 @@
 package pocketpal.frontend.exceptions;
 
+import pocketpal.frontend.constants.MessageConstants;
+
 /**
  * Exception thrown when user input entry ID is not recognised.
  */
 public class InvalidEntryIdException extends Exception {
     public InvalidEntryIdException(String message) {
         super(message);
+    }
+
+    public InvalidEntryIdException() {
+        super(MessageConstants.MESSAGE_INVALID_ID);
     }
 }

--- a/src/main/java/pocketpal/frontend/parser/Parser.java
+++ b/src/main/java/pocketpal/frontend/parser/Parser.java
@@ -435,8 +435,8 @@ public class Parser {
         Double priceMinDouble = Double.parseDouble(priceMinStr);
         Double priceMaxDouble = Double.parseDouble(priceMaxStr);
         if (priceMaxDouble < priceMinDouble) {
-            logger.warning("Maximum price range higher than minimum: " + MessageConstants.MESSAGE_INVALID_PRICE_RANGE);
-            throw new InvalidArgumentsException(MessageConstants.MESSAGE_INVALID_PRICE_RANGE);
+            logger.warning("Maximum price range higher than minimum: " + MessageConstants.MESSAGE_INVALID_AMOUNT_RANGE);
+            throw new InvalidArgumentsException(MessageConstants.MESSAGE_INVALID_AMOUNT_RANGE);
         }
         prices[0] = priceMinDouble;
         prices[1] = priceMaxDouble;
@@ -524,7 +524,7 @@ public class Parser {
     private void checkIfPriceValid(String price) throws InvalidArgumentsException {
         boolean isValid = price.matches(VALID_PRICE_REGEX);
         if (!isValid) {
-            throw new InvalidArgumentsException(MessageConstants.MESSAGE_INVALID_PRICE);
+            throw new InvalidArgumentsException(MessageConstants.MESSAGE_INVALID_AMOUNT);
         }
     }
 

--- a/src/main/java/pocketpal/frontend/util/StringUtil.java
+++ b/src/main/java/pocketpal/frontend/util/StringUtil.java
@@ -3,10 +3,26 @@ package pocketpal.frontend.util;
 import java.util.Arrays;
 
 public class StringUtil {
+    /**
+     * Format word in each string to have the first letter capitalised,
+     * and the rest in lowercase
+     * @param string String to be processed
+     * @return String in Title Case
+     */
     public static String toTitleCase(String string) {
         return Arrays.stream(string.split(" "))
                      .reduce("", (prevStr, currStr) -> prevStr
-                             + currStr.substring(0, 1).toUpperCase()
-                             + currStr.substring(1).toLowerCase());
+                             + currStr.substring(0, 1).toUpperCase() // the first letter
+                             + currStr.substring(1).toLowerCase()); // the remaining letters
+    }
+
+    /**
+     * Convert double to string without scientific notation.
+     *
+     * @param number Double to be converted
+     * @return String with up to 5 trailing zero decimal points
+     */
+    public static String doubleToString(double number) {
+        return String.format("%.5f", number);
     }
 }

--- a/src/test/java/pocketpal/backend/endpoints/EndpointUtilTest.java
+++ b/src/test/java/pocketpal/backend/endpoints/EndpointUtilTest.java
@@ -1,0 +1,86 @@
+package pocketpal.backend.endpoints;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import pocketpal.frontend.exceptions.InvalidArgumentsException;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@DisplayName("Test utility methods for Endpoint")
+public class EndpointUtilTest {
+    @Nested
+    @DisplayName("Test getPositiveIntegerFromString")
+    class TestGetPositiveIntegerFromString {
+        @Test
+        void getPositiveInteger_validInput_noExceptionThrown() {
+            assertDoesNotThrow(() -> {
+                int result = EndpointUtil.getPositiveIntegerFromString("1");
+                assertEquals(1, result);
+            });
+        }
+
+        @Test
+        void getPositiveInteger_nonInteger_throwsException() {
+            assertThrows(NumberFormatException.class,
+                    () -> EndpointUtil.getPositiveIntegerFromString("2147483648"));
+        }
+
+        @Test
+        void getPositiveInteger_zero_throwsException() {
+            assertThrows(NumberFormatException.class,
+                    () -> EndpointUtil.getPositiveIntegerFromString("0"));
+        }
+
+        @Test
+        void getPositiveInteger_negativeInteger_throwsException() {
+            assertThrows(NumberFormatException.class,
+                    () -> EndpointUtil.getPositiveIntegerFromString("-1"));
+        }
+    }
+
+    @Nested
+    @DisplayName("Test getAmountFromString")
+    class TestGetAmountFromString {
+        @Test
+        void getAmount_validInputInteger_noExceptionThrown() {
+            assertDoesNotThrow(() -> {
+                double result = EndpointUtil.getAmountFromString("1");
+                assertEquals(1, result);
+            });
+        }
+
+        @Test
+        void getAmount_validInputDouble_noExceptionThrown() {
+            assertDoesNotThrow(() -> {
+                double result = EndpointUtil.getAmountFromString("0.01");
+                assertEquals(0.01, result);
+            });
+        }
+
+        @Test
+        void getAmount_moreThanNineIntegers_exceptionThrown() {
+            assertThrows(InvalidArgumentsException.class, () -> EndpointUtil.getAmountFromString("1000000000.00"));
+        }
+        @Test
+        void getAmount_moreThanTwoDecimalPlaces_exceptionThrown() {
+            assertThrows(InvalidArgumentsException.class, () -> EndpointUtil.getAmountFromString("0.001"));
+        }
+        @Test
+        void getAmount_noLeadingZero_accepted() {
+            assertDoesNotThrow(() -> {
+                double result = EndpointUtil.getAmountFromString(".01");
+                assertEquals(0.01, result);
+            });
+        }
+        @Test
+        void getAmount_floatingPointWithoutDecimals_accepted() {
+            assertDoesNotThrow(() -> {
+                double result = EndpointUtil.getAmountFromString("1.");
+                assertEquals(1, result);
+            });
+        }
+    }
+}

--- a/src/test/java/pocketpal/backend/endpoints/EntriesEndpointTest.java
+++ b/src/test/java/pocketpal/backend/endpoints/EntriesEndpointTest.java
@@ -181,6 +181,7 @@ public class EntriesEndpointTest extends EntryTestUtil {
             addEntry(ENTRY_3); // Food poisoning
             addEntry(ENTRY_4); // Mango juice
             addEntry(ENTRY_5); // Bus ride home
+            expectedEntryLog.addEntry(ENTRY_2);
             expectedEntryLog.addEntry(ENTRY_4);
 
             Request request = new Request(RequestMethod.GET); // recent 3 entries

--- a/src/test/java/pocketpal/backend/endpoints/EntriesEndpointTest.java
+++ b/src/test/java/pocketpal/backend/endpoints/EntriesEndpointTest.java
@@ -12,6 +12,7 @@ import pocketpal.communication.ResponseStatus;
 import pocketpal.data.EntryTestUtil;
 import pocketpal.data.entrylog.EntryLog;
 import pocketpal.data.parsing.EntryLogParser;
+import pocketpal.frontend.constants.MessageConstants;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -158,6 +159,16 @@ public class EntriesEndpointTest extends EntryTestUtil {
         }
 
         @Test
+        void entriesEndpointGET_filterInvalidAmount_failure() {
+            Request request = new Request(RequestMethod.GET);
+            request.addParam(RequestParams.FILTER_BY_AMOUNT_END, "1000000000");
+            Response response = TEST_BACKEND.requestEndpointEntries(request);
+
+            assertEquals(response.getResponseStatus(), ResponseStatus.UNPROCESSABLE_CONTENT);
+            assertEquals(response.getData(), MessageConstants.MESSAGE_INVALID_AMOUNT);
+        }
+
+        @Test
         void entriesEndpointGET_filterQueryCaseInsensitive_correctEntries() {
             addEntry(ENTRY_1); // 5 packets of dried mango
             addEntry(ENTRY_2); // Grab ride to mango farm at 2am
@@ -192,6 +203,25 @@ public class EntriesEndpointTest extends EntryTestUtil {
 
             assertEquals(response.getResponseStatus(), ResponseStatus.OK);
             assertTrue(isSameEntryLog(expectedEntryLog, returnedEntryLog));
+        }
+        @Test
+        void entriesEndpointGET_numberGreaterThanInteger_exceptionThrown() {
+            Request request = new Request(RequestMethod.GET);
+            request.addParam(RequestParams.NUM_ENTRIES, "2147483648");
+            Response response = TEST_BACKEND.requestEndpointEntries(request);
+
+            assertEquals(response.getResponseStatus(), ResponseStatus.UNPROCESSABLE_CONTENT);
+            assertEquals(response.getData(), MessageConstants.MESSAGE_INVALID_NUMBER_OF_ENTRIES);
+        }
+
+        @Test
+        void entriesEndpointGET_zeroEntries_getFailure() {
+            Request request = new Request(RequestMethod.GET);
+            request.addParam(RequestParams.NUM_ENTRIES, "0");
+            Response response = TEST_BACKEND.requestEndpointEntries(request);
+
+            assertEquals(response.getResponseStatus(), ResponseStatus.UNPROCESSABLE_CONTENT);
+            assertEquals(response.getData(), MessageConstants.MESSAGE_INVALID_NUMBER_OF_ENTRIES);
         }
     }
 }

--- a/src/test/java/pocketpal/backend/endpoints/EntryEndpointTest.java
+++ b/src/test/java/pocketpal/backend/endpoints/EntryEndpointTest.java
@@ -13,6 +13,7 @@ import pocketpal.data.EntryTestUtil;
 import pocketpal.data.entry.Category;
 import pocketpal.data.entry.Entry;
 import pocketpal.data.parsing.EntryParser;
+import pocketpal.frontend.constants.MessageConstants;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -135,6 +136,18 @@ public class EntryEndpointTest extends EntryTestUtil {
             request.addParam(RequestParams.EDIT_CATEGORY, "Fruits");
             Response response = TEST_BACKEND.requestEndpointEntry(request);
             assertEquals(response.getResponseStatus(), ResponseStatus.UNPROCESSABLE_CONTENT);
+        }
+
+        @Test
+        void entryEndpointPATCH_invalidAmount_patchFailure() {
+            addEntry(ENTRY_1);
+
+            Request request = new Request(RequestMethod.PATCH, "1");
+            request.addParam(RequestParams.EDIT_AMOUNT, "2147483648");
+            Response response = TEST_BACKEND.requestEndpointEntry(request);
+
+            assertEquals(response.getResponseStatus(), ResponseStatus.UNPROCESSABLE_CONTENT);
+            assertEquals(response.getData(), MessageConstants.MESSAGE_INVALID_AMOUNT);
         }
     }
 

--- a/src/test/java/pocketpal/commands/ViewCommandTest.java
+++ b/src/test/java/pocketpal/commands/ViewCommandTest.java
@@ -3,6 +3,7 @@ package pocketpal.commands;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import pocketpal.backend.constants.MiscellaneousConstants;
 import pocketpal.data.EntryTestUtil;
 import pocketpal.data.entry.Category;
 import pocketpal.data.entry.Entry;
@@ -22,7 +23,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
 
-
 @DisplayName("Test view command")
 public class ViewCommandTest extends EntryTestUtil {
     private final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
@@ -31,9 +31,10 @@ public class ViewCommandTest extends EntryTestUtil {
     private final Entry testEntry2 = new Entry("Noodles", 9.40, Category.FOOD);
     private final Entry testEntry3 = new Entry("Cab", 10.80, Category.TRANSPORTATION);
     private final UI ui = new UI();
-    private EntryLog testEntries = new EntryLog();
+    private final EntryLog testEntries = new EntryLog();
+
     @BeforeEach
-    void init(){
+    void init() {
         testEntries.clearAllEntries();
         TEST_BACKEND.clearData();
         testEntries.addEntry(testEntry1);
@@ -47,10 +48,10 @@ public class ViewCommandTest extends EntryTestUtil {
 
     @Test
     @DisplayName("Test view by price range")
-    void testViewByPriceRange(){
-        try{
+    void testViewByPriceRange() {
+        try {
             ViewCommand testCommand =
-                    assertDoesNotThrow(() -> new ViewCommand(Integer.MAX_VALUE, null, 7.00, 10.50,"",""));
+                    assertDoesNotThrow(() -> new ViewCommand(Integer.MAX_VALUE, null, 7.00, 10.50, "", ""));
             testCommand.execute(TEST_UI, TEST_BACKEND);
             double expectedTotalPrice = 0;
             for (int index = 1; index <= 2; index++) {
@@ -62,7 +63,7 @@ public class ViewCommandTest extends EntryTestUtil {
                     .append(" entries.")
                     .append(System.lineSeparator());
             expectedString.append("Total expenditure: $" + expectedTotalPrice).append(System.lineSeparator());
-            for (int index = 1; index <= 2; index ++){
+            for (int index = 1; index <= 2; index++) {
                 String formattedEntry = ui.formatViewEntries(testEntries.getEntry(index), index);
                 expectedString.append(formattedEntry).append(System.lineSeparator());
             }
@@ -75,8 +76,9 @@ public class ViewCommandTest extends EntryTestUtil {
 
     @Test
     @DisplayName("Positive test for execute method for viewCommand")
-    void testExecuteMethod(){
-        ViewCommand viewCommand1 = new ViewCommand(10, Category.ENTERTAINMENT, 0.0, Double.MAX_VALUE,
+    void testExecuteMethod() {
+        ViewCommand viewCommand1 = new ViewCommand(10, Category.ENTERTAINMENT,
+                MiscellaneousConstants.AMOUNT_MIN_DOUBLE, MiscellaneousConstants.AMOUNT_MAX_DOUBLE,
                 "20/11/19 23:30", "20/11/20 23:30");
         assertDoesNotThrow(() -> viewCommand1.execute(TEST_UI, TEST_BACKEND));
     }
@@ -84,7 +86,8 @@ public class ViewCommandTest extends EntryTestUtil {
     @Test
     @DisplayName("Test execute method with invalid number of entries to view")
     void testExecuteMethod_invalidNumber() {
-        ViewCommand viewCommand2 = new ViewCommand(0, Category.ENTERTAINMENT, 0.0, Double.MAX_VALUE,
+        ViewCommand viewCommand2 = new ViewCommand(0, Category.ENTERTAINMENT,
+                MiscellaneousConstants.AMOUNT_MIN_DOUBLE, MiscellaneousConstants.AMOUNT_MAX_DOUBLE,
                 "20/11/19 23:30", "20/11/20 23:30");
         Exception invalidArgumentsException = assertThrows(InvalidArgumentsException.class,
                 () -> viewCommand2.execute(TEST_UI, TEST_BACKEND));

--- a/src/test/java/pocketpal/frontend/parser/ParserTest.java
+++ b/src/test/java/pocketpal/frontend/parser/ParserTest.java
@@ -70,7 +70,7 @@ public class ParserTest {
             parser.parseUserInput("/add -d expense1 -p 10f0 -c food");
         });
 
-        String expectedMessage = MessageConstants.MESSAGE_INVALID_PRICE;
+        String expectedMessage = MessageConstants.MESSAGE_INVALID_AMOUNT;
         String actualMessage = exception.getMessage();
         assertEquals(expectedMessage, actualMessage);
     }
@@ -135,7 +135,7 @@ public class ParserTest {
         Exception exception = assertThrows(InvalidArgumentsException.class, () -> {
             parser.parseUserInput("/edit 10 -p 10f");
         });
-        String expectedMessage = MessageConstants.MESSAGE_INVALID_PRICE;
+        String expectedMessage = MessageConstants.MESSAGE_INVALID_AMOUNT;
         String actualMessage = exception.getMessage();
         assertEquals(expectedMessage, actualMessage);
     }
@@ -179,7 +179,7 @@ public class ParserTest {
         Exception exception = assertThrows(InvalidArgumentsException.class, () -> {
             parser.parseUserInput("/view -p 20 -p 10");
         });
-        String expectedMessage = MessageConstants.MESSAGE_INVALID_PRICE_RANGE;
+        String expectedMessage = MessageConstants.MESSAGE_INVALID_AMOUNT_RANGE;
         String actualMessage = exception.getMessage();
         assertEquals(expectedMessage, actualMessage);
     }


### PR DESCRIPTION
Closes #123 
- only up to 9 digits are allowed for amount, with optional 2 decimal points
- introduce utility class for validating parameters from requests
- use boundary value analysis for unit tests
- allow flexible floating point input for amount
- use utility methods for consistent conversion from double to string