### PR TITLE
fix: view invalid id

### DIFF
--- a/src/main/java/pocketpal/backend/constants/MiscellaneousConstants.java
+++ b/src/main/java/pocketpal/backend/constants/MiscellaneousConstants.java
@@ -15,6 +15,8 @@ public final class MiscellaneousConstants {
             .compile("^(\\d{0,9}.(\\d{1,2}0*))$|^(\\d{1,9}(.\\d{0,2}0*)?)$");
     public static final double AMOUNT_MAX_DOUBLE = 999999999.99;
     public static final double AMOUNT_MIN_DOUBLE = 0.01;
+    public static final String AMOUNT_MAX_STRING = "999999999.99";
+    public static final String AMOUNT_MIN_STRING = "0.01";
     private MiscellaneousConstants(){
     }
 }

--- a/src/main/java/pocketpal/backend/endpoints/EntriesEndpoint.java
+++ b/src/main/java/pocketpal/backend/endpoints/EntriesEndpoint.java
@@ -83,7 +83,7 @@ public class EntriesEndpoint extends Endpoint {
             logger.warning("/entries [GET]: invalid number of entries requested");
             return new Response(
                     ResponseStatus.UNPROCESSABLE_CONTENT,
-                    MessageConstants.MESSAGE_INVALID_NUMBER_OF_ENTRIES
+                    MessageConstants.MESSAGE_INVALID_ID
             );
         } catch (InvalidArgumentsException e) {
             logger.warning("/entries [GET]: invalid arguments");

--- a/src/main/java/pocketpal/frontend/commands/ViewCommand.java
+++ b/src/main/java/pocketpal/frontend/commands/ViewCommand.java
@@ -58,7 +58,7 @@ public class ViewCommand extends Command {
             request.addParam(RequestParams.FILTER_BY_CATEGORY, category);
         }
         if (numberOfEntriesToView <= 0) {
-            throw new InvalidArgumentsException(MessageConstants.MESSAGE_INVALID_NUMBER_OF_ENTRIES);
+            throw new InvalidArgumentsException(MessageConstants.MESSAGE_INVALID_ID);
         }
         if (!startDateString.isEmpty() && !endDateString.isEmpty()){
             request.addParam(RequestParams.FILTER_BY_TIME_START, startDateString);

--- a/src/main/java/pocketpal/frontend/constants/MessageConstants.java
+++ b/src/main/java/pocketpal/frontend/constants/MessageConstants.java
@@ -49,7 +49,7 @@ public final class MessageConstants {
     public static final String MESSAGE_INVALID_COMMAND = "Please enter a valid command!";
     public static final String MESSAGE_INVALID_CATEGORY = "Please specify a valid category!";
     public static final String MESSAGE_INVALID_DESCRIPTION = "Description can only contain letters and numbers!";
-    public static final String MESSAGE_INVALID_ID = "Please enter a valid numerical index!";
+    public static final String MESSAGE_INVALID_ID = "Please enter an integer from 1 to 2147483647.";
     public static final String MESSAGE_INVALID_AMOUNT = "Please enter a valid amount!" + NEWLINE
             + "Value should be between 0.01 and 999999999.99";
     public static final String MESSAGE_INVALID_AMOUNT_RANGE = "Please specify a valid range!" + NEWLINE
@@ -64,7 +64,6 @@ public final class MessageConstants {
             " and make sure the date exists! eg. 12/01/99 or 12/12/00";
     public static final String MESSAGE_MIXED_DATE = "start date should be before end date!";
     public static final String MESSAGE_MISSING_DATE = "Please enter BOTH the start and end date!";
-    public static final String MESSAGE_INVALID_NUMBER_OF_ENTRIES = "Please enter a positive integer more than zero!";
     public static final String MESSAGE_INVALID_DATE_READ = "Date format not recognised.";
 
     private MessageConstants() {

--- a/src/main/java/pocketpal/frontend/parser/Parser.java
+++ b/src/main/java/pocketpal/frontend/parser/Parser.java
@@ -8,6 +8,7 @@ import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import pocketpal.backend.constants.MiscellaneousConstants;
 import pocketpal.data.entry.Category;
 import pocketpal.frontend.constants.EntryConstants;
 import pocketpal.frontend.constants.MessageConstants;
@@ -425,12 +426,12 @@ public class Parser {
         if (!priceMinStr.isEmpty()) {
             checkIfPriceValid(priceMinStr);
         } else {
-            priceMinStr = "0";
+            priceMinStr = MiscellaneousConstants.AMOUNT_MIN_STRING;
         }
         if (!priceMaxStr.isEmpty()) {
             checkIfPriceValid(priceMaxStr);
         } else {
-            priceMaxStr = Integer.toString(Integer.MAX_VALUE);
+            priceMaxStr = MiscellaneousConstants.AMOUNT_MAX_STRING;
         }
         Double priceMinDouble = Double.parseDouble(priceMinStr);
         Double priceMaxDouble = Double.parseDouble(priceMaxStr);

--- a/src/test/java/pocketpal/backend/endpoints/EntriesEndpointTest.java
+++ b/src/test/java/pocketpal/backend/endpoints/EntriesEndpointTest.java
@@ -211,7 +211,7 @@ public class EntriesEndpointTest extends EntryTestUtil {
             Response response = TEST_BACKEND.requestEndpointEntries(request);
 
             assertEquals(response.getResponseStatus(), ResponseStatus.UNPROCESSABLE_CONTENT);
-            assertEquals(response.getData(), MessageConstants.MESSAGE_INVALID_NUMBER_OF_ENTRIES);
+            assertEquals(response.getData(), MessageConstants.MESSAGE_INVALID_ID);
         }
 
         @Test
@@ -221,7 +221,7 @@ public class EntriesEndpointTest extends EntryTestUtil {
             Response response = TEST_BACKEND.requestEndpointEntries(request);
 
             assertEquals(response.getResponseStatus(), ResponseStatus.UNPROCESSABLE_CONTENT);
-            assertEquals(response.getData(), MessageConstants.MESSAGE_INVALID_NUMBER_OF_ENTRIES);
+            assertEquals(response.getData(), MessageConstants.MESSAGE_INVALID_ID);
         }
     }
 }

--- a/src/test/java/pocketpal/commands/ViewCommandTest.java
+++ b/src/test/java/pocketpal/commands/ViewCommandTest.java
@@ -91,7 +91,7 @@ public class ViewCommandTest extends EntryTestUtil {
                 "20/11/19 23:30", "20/11/20 23:30");
         Exception invalidArgumentsException = assertThrows(InvalidArgumentsException.class,
                 () -> viewCommand2.execute(TEST_UI, TEST_BACKEND));
-        assertEquals(invalidArgumentsException.getMessage(), MessageConstants.MESSAGE_INVALID_NUMBER_OF_ENTRIES);
+        assertEquals(invalidArgumentsException.getMessage(), MessageConstants.MESSAGE_INVALID_ID);
     }
 
 }


### PR DESCRIPTION
- updated parser default constants if amount start and end are not passed
- update exception message for invalid index/non-positive integers
