### PR TITLE
Add link to SimpleDateTime implementation to address issue #194

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -228,6 +228,10 @@ Note:
 Note:
 
 - `start_date`, `end_date` must be in `dd/MM/yy` format.
+  - *warning*: users are advised to set start date and end date parameters with a maximum interval of 5 years. This is
+    because of the
+    [implementation of SimpleDateTime](https://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html).
+
 - Both flags are **required** if user wishes to use this
   option.
 - `start_date` should not be after `end_date`.


### PR DESCRIPTION
Users are advised to set start and end date with a maximum of 5 years duration in between.