### PR TITLE
Modify checkDateValidity method in ParseCommand Class

### DIFF
--- a/src/main/java/pocketpal/frontend/parser/ParseCommand.java
+++ b/src/main/java/pocketpal/frontend/parser/ParseCommand.java
@@ -145,7 +145,7 @@ public abstract class ParseCommand {
             return;
         }
         Matcher matcher = ParserConstants.DATE_FORMATTER.matcher(dateString);
-        if (!matcher.find()) { //Date incorrect format
+        if (!matcher.matches()) { //Date incorrect format
             throw new InvalidDateException(MessageConstants.MESSAGE_INVALID_DATE);
         }
     }


### PR DESCRIPTION
date strings that don't strictly match dd/mm/yy format will trigger the InvalidDateException.